### PR TITLE
Fix em operacao ROR

### DIFF
--- a/simulator/vikingsim.py
+++ b/simulator/vikingsim.py
@@ -414,7 +414,7 @@ def cycle() :
 	if (opc == 10) :
 		if op2 == 0 :		context[rst] = (rs1 & 0xffff) >> 1
 		elif op2 == 1 :		context[rst] = rs1 >> 1
-		elif op2 ==  2 :	context[rst] = (carry << 15) & ((rs1 & 0xffff) >> 1)
+		elif op2 ==  2 :	context[rst] = (carry << 15) | ((rs1 & 0xffff) >> 1)
 		else :
 					out.insert(END, ("\nInvalid shift instruction at %04x.\n" % context[8]))
 					out.see(END)


### PR DESCRIPTION
Estava deslocando os bits de rs1 1 vez para direita e fazendo um AND com o (carry << 15), o que sempre retorna 0.
O AND foi trocado por um OR para manter o bit do carry e o resto dos bits do rs1 (fazendo uma rotacao).